### PR TITLE
Add date => type/Date map

### DIFF
--- a/src/metabase/driver/athena.clj
+++ b/src/metabase/driver/athena.clj
@@ -59,6 +59,7 @@
     :varbinary  :type/*
     :boolean    :type/Boolean
     :char       :type/Text
+    :date       :type/Date
     :decimal    :type/Decimal
     :double     :type/Float
     :float      :type/Float


### PR DESCRIPTION
I was getting this warning:
05-09 19:03:36 WARN driver.athena :: Don't know how to map column type 'date' to a Field base_type, falling back to :type/*.

Filtering by date still doesn't work in the query builder though:
No method in multimethod 'date' for dispatch value: [:athena :day]