### PR TITLE
Use DefaultAWSCredentialsProviderChain when missing access key id

### DIFF
--- a/src/metabase/driver/athena.clj
+++ b/src/metabase/driver/athena.clj
@@ -56,6 +56,8 @@
     :s3_staging_dir  s3_staging_dir
     ; :LogLevel    6
     }
+   (when (str/blank? access_key)
+     {:AwsCredentialsProviderClass "com.simba.athena.amazonaws.auth.DefaultAWSCredentialsProviderChain"})
    (dissoc details :db)))
 
 ;;; ------------------------------------------------- sql-jdbc.sync --------------------------------------------------


### PR DESCRIPTION
This allows the use of EC2 instance profile credentials (via the EC2 metadata service), environment variables, Java system props, etc

closes #16