### PR TITLE
Add Workgroup configuration option

### DIFF
--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -1,7 +1,7 @@
 # Complete list of options here: https://github.com/metabase/metabase/wiki/Metabase-Plugin-Manifest-Reference
 info:
   name: Metabase Athena Driver
-  version: 0.1.0-athena-jdbc-2.0.7
+  version: 0.1.1-athena-jdbc-2.0.7
   description: Allows Metabase to connect to AWS Athena databases. Community Supported driver.
 driver:
   name: athena

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -12,6 +12,9 @@ driver:
     - name: region
       display-name: Region
       default: "us-east-1"
+    - name: workgroup
+      display-name: Workgroup
+      default: "primary"
     - name: s3_staging_dir
       display-name: S3 Staging dir
       default: s3://your_bucket

--- a/src/metabase/driver/athena.clj
+++ b/src/metabase/driver/athena.clj
@@ -46,7 +46,7 @@
 
 ;;; ---------------------------------------------- sql-jdbc.connection -----------------------------------------------
 
-(defmethod sql-jdbc.conn/connection-details->spec :athena [_ {:keys [region access_key secret_key s3_staging_dir db], :as details}]
+(defmethod sql-jdbc.conn/connection-details->spec :athena [_ {:keys [region access_key secret_key s3_staging_dir workgroup db], :as details}]
   (merge
    {:classname   "com.simba.athena.jdbc.Driver"
     :subprotocol "awsathena"
@@ -54,6 +54,7 @@
     :user        access_key
     :password    secret_key
     :s3_staging_dir  s3_staging_dir
+    :workgroup workgroup
     ; :LogLevel    6
     }
    (dissoc details :db)))


### PR DESCRIPTION
This adds the Workgroup arg to the driver setup, with primary as the default. I tried this locally and it seems to work fine.