### PR TITLE
Added unix-timestamp->timestamp function.

### DIFF
--- a/src/metabase/driver/athena.clj
+++ b/src/metabase/driver/athena.clj
@@ -137,6 +137,8 @@
 
 (defmethod sql.qp/current-datetime-fn :athena [_] (du/->Timestamp (System/currentTimeMillis)))
 
+(defmethod sql.qp/unix-timestamp->timestamp [:athena :seconds] [_ _ expr] (hsql/call :from_unixtime expr))
+
 (defmethod driver/date-add :athena [driver dt amount unit] (du/relative-date unit amount dt))
 
 ;; keyword function converts database-type variable to a symbol, so we use symbols above to map the types


### PR DESCRIPTION
Following the implementation of relative-date querying, we had issues running queries built with the editor when the DB model was set to Unix Timestamp.

Issue encountered : 
"No method in multimethod 'unix-timestamp->timestamp' for dispatch value: [:athena :seconds]"

I've just added the the unix-timestamp->timestamp function that we can find in many others drivers to resolve the problem.