### PR TITLE
Update driver for time changes in 0.34

### DIFF
--- a/src/metabase/driver/athena.clj
+++ b/src/metabase/driver/athena.clj
@@ -1,6 +1,6 @@
 (ns metabase.driver.athena
-  (:refer-clojure :exclude [second])
-  (:require [metabase.driver.schema-parser :as schema-parser]
+    (:refer-clojure :exclude [second])
+    (:require [metabase.driver.schema-parser :as schema-parser]
             [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
@@ -10,28 +10,27 @@
              [field :as field :refer [Field]]]
             [metabase.driver.query-processor :as qp]
             [honeysql
-             [core :as hsql]
-             [format :as hformat]]
+             [core :as hsql]]
+            [java-time :as t]
             [metabase.driver :as driver]
             [metabase.driver.common :as driver.common]
             [metabase.driver.sql-jdbc
              [connection :as sql-jdbc.conn]
              [execute :as sql-jdbc.execute]
              [sync :as sql-jdbc.sync]]
+            [metabase.driver.sql-jdbc.execute.legacy-impl :as legacy]
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.driver.sql.util.unprepare :as unprepare]
             [metabase.util
-             [date :as du]
+             [date-2 :as u.date]
              [honeysql-extensions :as hx]
              [i18n :refer [trs]]]
             [metabase.util :as u]
             [clojure.string :as string])
-  (:import [java.sql DatabaseMetaData Timestamp]
-           java.util.Date
-           java.sql.Time
-           (org.quartz Calendar)))
+    (:import [java.sql DatabaseMetaData Timestamp]
+      (org.quartz Calendar) (java.time OffsetDateTime ZonedDateTime)))
 
-(driver/register! :athena, :parent :sql-jdbc)
+(driver/register! :athena, :parent #{:sql-jdbc, ::legacy/use-legacy-classes-for-read-and-set})
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -90,10 +89,13 @@
     :varchar    :type/Text} database-type))
 
 ;;; ------------------------------------------------- date functions -------------------------------------------------
-(defmethod unprepare/unprepare-value [:athena Date] [_ value]
-  (unprepare/unprepare-date-with-iso-8601-fn :from_iso8601_timestamp value))
+(defmethod unprepare/unprepare-value [:presto OffsetDateTime]
+  [_ t]
+  (format "timestamp '%s %s %s'" (t/local-date t) (t/local-time t) (t/zone-offset t)))
 
-(prefer-method unprepare/unprepare-value [:sql Time] [:athena Date])
+(defmethod unprepare/unprepare-value [:presto ZonedDateTime]
+  [_ t]
+  (format "timestamp '%s %s %s'" (t/local-date t) (t/local-time t) (t/zone-id t)))
 
 ; Helper function for truncating dates - currently unused
 (defn- date-trunc [unit expr] (hsql/call :date_trunc (hx/literal unit) expr))
@@ -135,11 +137,11 @@
 
 (defmethod sql.qp/->honeysql [:athena (class Field)] [driver field] (qp/->honeysql driver field))
 
-(defmethod sql.qp/current-datetime-fn :athena [_] (du/->Timestamp (System/currentTimeMillis)))
+(defmethod sql.qp/current-datetime-fn :athena [_] (u.date/parse (System/currentTimeMillis)))
 
 (defmethod sql.qp/unix-timestamp->timestamp [:athena :seconds] [_ _ expr] (hsql/call :from_unixtime expr))
 
-(defmethod driver/date-add :athena [driver dt amount unit] (du/relative-date unit amount dt))
+(defmethod driver/date-add :athena [driver dt amount unit] (u.date/add unit amount dt))
 
 ;; keyword function converts database-type variable to a symbol, so we use symbols above to map the types
 (defn- database-type->base-type-or-warn

--- a/test/metabase/driver/athena_test.clj
+++ b/test/metabase/driver/athena_test.clj
@@ -74,7 +74,6 @@
                                                                  :base_type     :type/DateTime}
                                                                 ]
                                                   :native_form       {:query relative-date-query}
-                                                  :requested_timezone "UTC"
                                                   :results_timezone   "UTC"}}
 
                              (-> (process-native-query relative-date-query)))
@@ -84,7 +83,7 @@
 (datasets/expect-with-driver :athena
                              {:row_count     1
                              :status        :completed
-                             :data          {:rows        [["2006-01-02T00:00:00.000Z" "15:04:05.000" "15:04:05.000 America/Los_Angeles" "2006-01-02T15:04:05.000Z" "2006-01-02 15:04:05.000 America/Los_Angeles" "0-3" "2 00:00:00.000"]]
+                             :data          {:rows        [["2006-01-02T00:00:00Z" "15:04:05.000" "15:04:05.000 America/Los_Angeles" "2006-01-02T15:04:05Z" "2006-01-02 15:04:05.000 America/Los_Angeles" "0-3" "2 00:00:00.000"]]
                                              :cols        [{:name           "type_date"
                                                             :display_name   "type_date"
                                                             :base_type      :type/Date
@@ -121,7 +120,6 @@
                                                             :source         :native
                                                             :field_ref      [:field-literal "type_interval_day_to_second" :type/Text]}]
                                              :native_form {:query datetime-types-query}
-                                             :requested_timezone  "UTC"
                                              :results_timezone    "UTC"}}
                              (-> (process-native-query datetime-types-query)))
 

--- a/test/metabase/test/data/athena.clj
+++ b/test/metabase/test/data/athena.clj
@@ -22,7 +22,7 @@
              [load-data :as load-data]]
             [metabase.test.data.sql.ddl :as ddl]
             [metabase.util
-             [date :as du]
+             [date-2 :as u.date]
              [honeysql-extensions :as hx]])
   (:import java.util.Date
            java.sql.Time))
@@ -31,22 +31,6 @@
 
 ;; during unit tests don't treat athena as having FK support
 (defmethod driver/supports? [:athena :foreign-keys] [_ _] (not config/is-test?))
-
-;; Override unprepare for date types as Athena doesn't support inserting "timestamp with time zone" values,
-;; which is what the from_iso8601_timestamp() function returns.
-(defmethod unprepare/unprepare-value [:athena Date] [_ value]
-  (format "from_unixtime(to_unixtime(%s))"
-          (hformat/to-sql
-            (hsql/call :from_iso8601_timestamp (hx/literal (du/date->iso-8601 value))))
-          ))
-
-;; Override unprepare for Time types as this was causing errors in INSERTs - we may need to fix this in the main driver
-;; TODO: Fix the from/to_unixtime shenanigans - they were used while testing how to implement this
-(defmethod unprepare/unprepare-value [:athena Time] [_ value]
-  (format "from_unixtime(to_unixtime(%s))"
-          (hformat/to-sql
-            (hsql/call :from_iso8601_timestamp (hx/literal (du/date->iso-8601 value))))
-          ))
 
 ;;; ----------------------------------------------- Connection Details -----------------------------------------------
 


### PR DESCRIPTION
- Athena driver does not support the necessary java.time types, so use legacy classes
- Replace some deprecated methods

Fixes #26 and fixes #27