### PR TITLE
Upgrade Athena JDBC driver to 2.0.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,8 @@ jobs:
       - run:
           name: Download Athena driver
           command: |
-            mkdir -p ~/.m2/repository/athena/athena-jdbc/2.0.9/
-            wget -O ~/.m2/repository/athena/athena-jdbc/2.0.9/athena-jdbc-2.0.9.jar https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC_2.0.9/AthenaJDBC42_2.0.9.jar
+            mkdir -p ~/.m2/repository/athena/athena-jdbc/2.0.13/
+            wget -O ~/.m2/repository/athena/athena-jdbc/2.0.13/athena-jdbc-2.0.13.jar https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC_2.0.13/AthenaJDBC42_2.0.13.jar
       - run:
           name: Build and install Metabase driver components
           working_directory: metabase

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can provide additional options if necessary. For example, to disable result 
 Result set streaming is a performance optimization that streams results from Athena rather than using pagination logic, however it requries outbound access to TCP port 444 and not all organizations allow that.
 
 Other options can be found in the "Driver Configuration Options" section of the [Athena JDBC Driver Installation and Configuration
-Guide](https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC_2.0.9/docs/Simba+Athena+JDBC+Driver+Install+and+Configuration+Guide.pdf).
+Guide](https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC_2.0.13/docs/Simba+Athena+JDBC+Driver+Install+and+Configuration+Guide.pdf).
 
 ## Contributing
 
@@ -78,8 +78,8 @@ I'm not familiar enough with `lein` to know if there is a better way to include 
 2. Download the Athena driver into your local Maven repo
 
    ```shell
-   mkdir -p ~/.m2/repository/athena/athena-jdbc/2.0.9/
-   wget -O ~/.m2/repository/athena/athena-jdbc/2.0.9/athena-jdbc-2.0.9.jar https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC_2.0.9/AthenaJDBC42_2.0.9.jar
+   mkdir -p ~/.m2/repository/athena/athena-jdbc/2.0.13/
+   wget -O ~/.m2/repository/athena/athena-jdbc/2.0.13/athena-jdbc-2.0.13.jar https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC_2.0.13/AthenaJDBC42_2.0.13.jar
    ```
 
 3. Clone this repo

--- a/project.clj
+++ b/project.clj
@@ -1,13 +1,13 @@
-(defproject metabase/athena-driver "1.0.0-athena-jdbc-2.0.9"
+(defproject metabase/athena-driver "1.0.0-athena-jdbc-2.0.13"
   :min-lein-version "2.5.0"
 
   :dependencies
-  [[athena/athena-jdbc "2.0.9"]]
+  [[athena/athena-jdbc "2.0.13"]]
 
 ;   :repositories
-;  [["athena" {:url "https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC_2.0.9/AthenaJDBC42_2.0.9.jar"}]]
+;  [["athena" {:url "https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC_2.0.13/AthenaJDBC42_2.0.13.jar"}]]
 ; TODO: Download from source URL
-; For now, you have to download the jar above into ~/.m2/repository/athena/athena-jdbc/2.0.9/athena-jdbc-2.0.9.jar
+; For now, you have to download the jar above into ~/.m2/repository/athena/athena-jdbc/2.0.13/athena-jdbc-2.0.13.jar
 
   :aliases
   {"test"       ["with-profile" "+unit_tests" "test"]}

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -1,7 +1,7 @@
 # Complete list of options here: https://github.com/metabase/metabase/wiki/Metabase-Plugin-Manifest-Reference
 info:
   name: Metabase Athena Driver
-  version: 1.0.0-athena-jdbc-2.0.9
+  version: 1.0.0-athena-jdbc-2.0.13
   description: Allows Metabase to connect to AWS Athena databases. Community Supported driver.
 driver:
   name: athena


### PR DESCRIPTION
Resoves #51 

One additional thing to test as part of this upgrade:
- ~[ ] Multi-catalog setups~

Multi-catalog setups will require some modification of the code to include a call to `getCatalogs`. That's outside the scope for this.