### PR TITLE
Fix to allow integer division to be cast as double

### DIFF
--- a/src/metabase/driver/athena.clj
+++ b/src/metabase/driver/athena.clj
@@ -152,6 +152,11 @@
              (hsql/raw (int amount))
              (hx/->timestamp hsql-form)))
 
+;; fix to allow integer division to be cast as double (float is not suported by athena)
+(defmethod sql.qp/->float :athena
+  [_ value]
+  (hx/cast :double value))
+
 ;; keyword function converts database-type variable to a symbol, so we use symbols above to map the types
 (defn- database-type->base-type-or-warn
   "Given a `database-type` (e.g. `VARCHAR`) return the mapped Metabase type (e.g. `:type/Text`)."


### PR DESCRIPTION
I found a bug that generates an error when you try to divide to fields in metabase. 

[Simba][AthenaJDBC](100071) An error has been thrown from the AWS Athena client. SYNTAX_ERROR: line 2:71: Unknown type: float [Execution ID: 2088bd6d-2f44-4b6c-8088-1f76c47b715d]

This error is generated because in the following pull request Metabase adds a Cast to Float to every division. However Athena doesn't support Float. It should be cast as double. 

https://github.com/metabase/metabase/pull/11116