### PR TITLE
Added scripts for jar setup, and in-project maven repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ pom.xml.asc
 /classes/
 /target/
 /checkouts/
+/maven_repository/
 .lein-deps-sum
 .lein-repl-history
 .lein-plugins/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+JAR_VERSION = 2.0.13
+JAR_URL = https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC_$(JAR_VERSION)/AthenaJDBC42_$(JAR_VERSION).jar
+
+# Source: https://www.pgrs.net/2011/10/30/using-local-jars-with-leiningen/
+download-jar:
+	mkdir -p maven_repository/athena/athena-jdbc/$(JAR_VERSION)/
+	cd maven_repository/athena/athena-jdbc/$(JAR_VERSION)/ \
+		&& curl $(JAR_URL) --output athena-jdbc-${JAR_VERSION}.jar --silent --show-error --continue-at - \
+		&& shasum athena-jdbc-$(JAR_VERSION).jar | cut -f "1" -d " " > athena-jdbc-$(JAR_VERSION).jar.sha1
+
+build: download-jar
+	DEBUG=1 LEIN_SNAPSHOTS_IN_RELEASE=true lein uberjar

--- a/README.md
+++ b/README.md
@@ -71,28 +71,27 @@ Guide](https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC_2.
 
 ### Build from source
 
-I'm not familiar enough with `lein` to know if there is a better way to include a jar from a static URL, so for the time being we download it manually.
-
 1. Download a fairly recent Metabase binary release (jar file) from the [Metabase distribution page](https://metabase.com/start/jar.html).
 
-2. Download the Athena driver into your local Maven repo
-
-   ```shell
-   mkdir -p ~/.m2/repository/athena/athena-jdbc/2.0.13/
-   wget -O ~/.m2/repository/athena/athena-jdbc/2.0.13/athena-jdbc-2.0.13.jar https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC_2.0.13/AthenaJDBC42_2.0.13.jar
-   ```
-
-3. Clone this repo
+2. Clone this repo
 
    ```shell
    git clone https://github.com/dacort/metabase-athena-driver
+   cd metabase-athena-driver/
+   ```
+
+3. Download the Athena driver into a local in-project Maven repo
+
+   ```shell
+   make download-jar
    ```
 
 4. Build the jar
 
    ```shell
-   cd metabase-athena-driver/
-   DEBUG=1 LEIN_SNAPSHOTS_IN_RELEASE=true lein uberjar
+   make build
+   # Alternative:
+   #   DEBUG=1 LEIN_SNAPSHOTS_IN_RELEASE=true lein uberjar
    ```
 
 5. Let's assume we download `metabase.jar` to `~/metabae/` and we built the project above. Copy the built jar to the Metabase plugins directly and run Metabase from there!

--- a/project.clj
+++ b/project.clj
@@ -1,13 +1,11 @@
 (defproject metabase/athena-driver "1.0.0-athena-jdbc-2.0.13"
   :min-lein-version "2.5.0"
 
+  ; Run `make download-jar` first, to initialize in-project maven repo and download third-party jar.
+  :repositories {"local" ~(str (.toURI (java.io.File. "maven_repository")))}
+
   :dependencies
   [[athena/athena-jdbc "2.0.13"]]
-
-;   :repositories
-;  [["athena" {:url "https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC_2.0.13/AthenaJDBC42_2.0.13.jar"}]]
-; TODO: Download from source URL
-; For now, you have to download the jar above into ~/.m2/repository/athena/athena-jdbc/2.0.13/athena-jdbc-2.0.13.jar
 
   :aliases
   {"test"       ["with-profile" "+unit_tests" "test"]}


### PR DESCRIPTION
Thanks for this driver. Great for learning driver development with :)

What I added:

- replaced user-level maven repo with project-level maven repo (not in version-control)
- added makefile (inits maven repo, downloads jar, builds)
- small readme updates

Hopefully `make` is a universal enough build tool to lean on here. Leiningen seems quite complicated, so I'm not even sure if it has build-tool style stuff, but I added what I knew.

Just scripting some of the stuff you mention in README, so it's executable, and happens all within the git repo dir hierarchy itself. (I don't know much about the java dev ecosystem, but usually try not to mess around with work-around feeling stuff outside my project root, if possible, hence getting it all happening in local files)

Also, seems the leiningen has gotten more strict with needing checksums, as I believe I was getting errors instead of warnings about the checksum being missing. Hence me adding checksum work-around :/

Thanks very much!