### PR TITLE
Get `MANAGED_TABLE`s

### DIFF
--- a/src/metabase/driver/athena.clj
+++ b/src/metabase/driver/athena.clj
@@ -241,11 +241,11 @@
                           (describe-table-fields metadata database driver table)
                           (catch Throwable e (set nil)))))))
 
-;; EXTERNAL_TABLE is required for Athena
+;; Athena can query EXTERNAL and MANAGED tables
 (defn- get-tables [^DatabaseMetaData metadata, ^String schema-or-nil, ^String db-name-or-nil]
   ;; tablePattern "%" = match all tables
   (with-open [rs (.getTables metadata db-name-or-nil schema-or-nil "%"
-                             (into-array String ["EXTERNAL_TABLE", "EXTERNAL TABLE" "TABLE", "VIEW", "VIRTUAL_VIEW", "FOREIGN TABLE", "MATERIALIZED VIEW"]))]
+                             (into-array String ["EXTERNAL_TABLE", "EXTERNAL TABLE" "TABLE", "VIEW", "VIRTUAL_VIEW", "FOREIGN TABLE", "MATERIALIZED VIEW", "MANAGED_TABLE"]))]
     (vec (jdbc/metadata-result rs))))
 
 ;; Required because we're calling our own custom private get-tables method to support Athena


### PR DESCRIPTION
Athena is capable of querying managed tables in glue - this adds `MANAGED_TABLE` to the list of retrievable tables

Fixes dacort/metabase-athena-driver#91