### PR TITLE
Update plugin YAML to use new advanced-option plugin fields

### DIFF
--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -24,10 +24,12 @@ driver:
         - password
         - display-name: Secret Key
           name: secret_key
+    - advanced-options-start
     - merge:
         - additional-options
         - display-name: Additional Athena connection string options
           placeholder: "UseResultsetStreaming=0;LogLevel=6"
+    - default-advanced-options
 init:
   - step: load-namespace
     namespace: metabase.driver.athena


### PR DESCRIPTION
Due to this change [https://github.com/metabase/metabase/pull/19262](https://github.com/metabase/metabase/pull/19262)
in the latest version of Metabase, the advanced configuration section is not showing up in the add Athena database dialog. 

This PR addresses the relevant YAML field changes to the plugin YAML to show the advanced configuration section.

Kindly suggest changes if any.

Steps to reproduce the issue
1. Start metabase latest v.0.42 with athena.metabase-driver.jar v1.3.0
2. Try adding Athena database with Advanced configuration options
3. Advanced configuration option doesn't show up

With athena.metabase-driver.jar v1.3.0 on metabase v.0.42
<img width="768" alt="Screenshot 2022-02-10 at 7 23 51 PM" src="https://user-images.githubusercontent.com/1904958/153421862-363ea95b-7767-407c-aa66-1df350b36cc6.png">

With athena.metabase-driver.jar built on this branch on metabase v.0.42

<img width="883" alt="Screenshot 2022-02-10 at 7 21 03 PM" src="https://user-images.githubusercontent.com/1904958/153422015-01cf360a-b25d-43fa-905f-b9b64e26a16a.png">


