### PR TITLE
v0.43.0 Compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-ARG METABASE_VERSION=v0.42.0
+ARG METABASE_VERSION=v0.43.0
 
 FROM clojure:openjdk-11-tools-deps-slim-buster AS stg_base
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-ARG METABASE_VERSION=v0.43.0
+ARG METABASE_VERSION=v0.43.1
 
 FROM clojure:openjdk-11-tools-deps-slim-buster AS stg_base
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![CircleCI](https://img.shields.io/circleci/build/github/dacort/metabase-athena-driver)](https://circleci.com/gh/dacort/metabase-athena-driver)
 [![Latest Release](https://img.shields.io/github/v/release/dacort/metabase-athena-driver.svg?label=latest%20release&include_prereleases)](https://github.com/dacort/metabase-athena-driver/releases)
-![Tested with Metabase v0.41.1](https://img.shields.io/badge/metabase-v0.41.1-blue?)
+![Tested with Metabase v0.43.1](https://img.shields.io/badge/metabase-v0.43.1-blue?)
 [![GitHub license](https://img.shields.io/github/license/dacort/metabase-athena-driver)](https://raw.githubusercontent.com/dacort/metabase-athena-driver/master/LICENSE)
 
 ## Installation

--- a/src/metabase/driver/athena.clj
+++ b/src/metabase/driver/athena.clj
@@ -152,10 +152,19 @@
              (hsql/raw (int amount))
              (hx/->timestamp hsql-form)))
 
-;; fix to allow integer division to be cast as double (float is not suported by athena)
+;; fix to allow integer division to be cast as double (float is not supported by athena)
 (defmethod sql.qp/->float :athena
   [_ value]
   (hx/cast :double value))
+
+;; Support for median/percentile functions
+(defmethod sql.qp/->honeysql [:athena :median]
+  [driver [_ arg]]
+  (hsql/call :approx_percentile (sql.qp/->honeysql driver arg) 0.5))
+
+(defmethod sql.qp/->honeysql [:athena :percentile]
+  [driver [_ arg p]]
+  (hsql/call :approx_percentile (sql.qp/->honeysql driver arg) (sql.qp/->honeysql driver p)))
 
 ;; keyword function converts database-type variable to a symbol, so we use symbols above to map the types
 (defn- database-type->base-type-or-warn


### PR DESCRIPTION
- Tested on Metavase v0.43.1
- Adds support for percentile and median - fixes #102 