### PR TITLE
Update Athena JDBC driver version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-ARG METABASE_VERSION=v0.44.2
+ARG METABASE_VERSION=v0.44.4
 
 FROM clojure:openjdk-11-tools-deps-slim-buster AS stg_base
 

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,12 @@
-JAR_VERSION = 2.0.32
+JAR_VERSION = 2.0.33
 VERSION_WITH_AWS_SDK = $(JAR_VERSION).1000
-ZIP_URL = https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC-$(VERSION_WITH_AWS_SDK)/SimbaAthenaJDBC-$(VERSION_WITH_AWS_SDK).zip
+JAR_URL = https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC-$(VERSION_WITH_AWS_SDK)/SimbaAthenaJDBC42-$(VERSION_WITH_AWS_SDK)/AthenaJDBC42-$(JAR_VERSION).jar
 
 # Source: https://www.pgrs.net/2011/10/30/using-local-jars-with-leiningen/
 maven_repository/athena/athena-jdbc/$(JAR_VERSION)/athena-jdbc-${JAR_VERSION}.jar.sha1:
 	mkdir -p maven_repository/athena/athena-jdbc/$(JAR_VERSION)/
 	cd maven_repository/athena/athena-jdbc/$(JAR_VERSION)/ \
-		&& curl $(ZIP_URL) --output athena-jdbc-${JAR_VERSION}.zip \
-		&& unzip -jo athena-jdbc-${JAR_VERSION}.zip \
-		&& unzip -jo SimbaAthenaJDBC42-${VERSION_WITH_AWS_SDK}.zip \
-		&& ln -s AthenaJDBC42.jar athena-jdbc-${JAR_VERSION}.jar \
-		&& sha1sum athena-jdbc-${JAR_VERSION}.jar | cut -f "1" -d " " > athena-jdbc-${JAR_VERSION}.jar.sha1 \
-		&& rm *.zip
+		&& curl $(JAR_URL) --output athena-jdbc-${JAR_VERSION}.jar --silent --show-error --continue-at - \
+		&& sha1sum athena-jdbc-${JAR_VERSION}.jar | cut -f "1" -d " " > athena-jdbc-${JAR_VERSION}.jar.sha1
 
 download-jar: maven_repository/athena/athena-jdbc/$(JAR_VERSION)/athena-jdbc-${JAR_VERSION}.jar.sha1

--- a/README.md
+++ b/README.md
@@ -256,3 +256,12 @@ docker build --output jars --target stg_export .
 docker build -t metabase/athena .
 docker run --rm --name metabase-athena -p 3000:3000 metabase/athena
 ```
+
+If you have an existing Metabase database you'd like to use, you can use the following command.
+
+```shell
+docker run --rm  -p 3000:3000 \
+  -v ~/metabase-data:/metabase-data \
+  -e MB_DB_FILE=/metabase-data/metabase.db \
+  --name metabase-athena metabase/athena
+```

--- a/deps.edn
+++ b/deps.edn
@@ -5,7 +5,7 @@
  {"athena" {:url "file:maven_repository"}}
 
  :deps
- {athena/athena-jdbc {:mvn/version "2.0.32"}}
+ {athena/athena-jdbc {:mvn/version "2.0.33"}}
 
  ;; build the driver with clojure -X:build
  :aliases


### PR DESCRIPTION
- Update Athena JDBC driver to v2.0.33 to address generic exception messages
- Change the makefile to only download the necessary jar file