### PR TITLE
Account for Iceberg tables which have spaces in the struct definitions

### DIFF
--- a/src/metabase/driver/hive_parser.clj
+++ b/src/metabase/driver/hive_parser.clj
@@ -28,12 +28,12 @@
              (str result "{"))
 
       (clojure.string/starts-with? schema ":")
-      (recur (clojure.string/replace-first schema #":" "")
+      (recur (clojure.string/replace-first schema #":\s*" "")
              closes
              (str result ":"))
 
       (clojure.string/starts-with? schema ",")
-      (recur (clojure.string/replace-first schema #"," "")
+      (recur (clojure.string/replace-first schema #",\s*" "")
              closes
              (str result ","))
 

--- a/test_unit/metabase/driver/hive_parser_test.clj
+++ b/test_unit/metabase/driver/hive_parser_test.clj
@@ -15,3 +15,18 @@
     (is (=
          {:grouperrors "string" :grouperrorsorder [] :fielderrors {:reviewtext {:field "string"} :title {:field "string"}} :fielderrorsorder []}
          (hive-schema->map "struct<grouperrors:string,grouperrorsorder:array<string>,fielderrors:struct<reviewtext:struct<field:string>,title:struct<field:string>>,fielderrorsorder:array<string>>")))))
+
+    (is (=
+         [{:customerid "string" :Order "bigint"}]
+         (hive-schema->map "array<struct<customerid:string,Order:bigint>>")))
+
+    (is (=
+         {:accredited_buyer_representative_abr "boolean"}
+         (hive-schema->map "struct<accredited_buyer_representative_abr: boolean>")))
+
+    (is (=
+         {:mediacategory "string" :mediakey "string" :mediaurl "string" :order "bigint"}
+         (hive-schema->map "struct<mediacategory: string, mediakey: string, mediaurl: string, order: bigint>")))
+
+    
+


### PR DESCRIPTION
Fixes #112 - Iceberg tables (and maybe all non-external tables?) return spaces in the struct definition. The original schema parsing code doesn't account for this and fails to identify any fields.

It should be noted that even though this parses the structs properly, nested fields still aren't supported. See https://github.com/starburstdata/metabase-driver/issues/22 for more details.