### PR TITLE
Remove timestamp casts from date_add

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-ARG METABASE_VERSION=v0.44.4
+ARG METABASE_VERSION=v0.44.6
 
 FROM clojure:openjdk-11-tools-deps-slim-buster AS stg_base
 

--- a/src/metabase/driver/athena.clj
+++ b/src/metabase/driver/athena.clj
@@ -126,8 +126,8 @@
 
 ; If `expr` is a date, we need to cast it to a timestamp before we can truncate to a finer granularity
 ; Ideally, we should make this conditional. There's a generic approach above, but different use cases should b tested.
-(defmethod sql.qp/date [:athena :minute]          [_ _ expr] (hsql/call :date_trunc (hx/literal :minute) (expr->literal expr)))
-(defmethod sql.qp/date [:athena :hour]            [_ _ expr] (hsql/call :date_trunc (hx/literal :hour) (expr->literal expr)))
+(defmethod sql.qp/date [:athena :minute]          [_ _ expr] (hsql/call :date_trunc (hx/literal :minute) expr))
+(defmethod sql.qp/date [:athena :hour]            [_ _ expr] (hsql/call :date_trunc (hx/literal :hour) expr))
 (defmethod sql.qp/date [:athena :day]             [_ _ expr] (hsql/call :date_trunc (hx/literal :day) expr))
 (defmethod sql.qp/date [:athena :week]            [_ _ expr] (hsql/call :date_trunc (hx/literal :week) expr))
 (defmethod sql.qp/date [:athena :month]           [_ _ expr] (hsql/call :date_trunc (hx/literal :month) expr))
@@ -152,7 +152,7 @@
   (hsql/call :date_add
              (hx/literal (name unit))
              (hsql/raw (int amount))
-             (hx/->timestamp hsql-form)))
+             hsql-form))
 
 ;; fix to allow integer division to be cast as double (float is not supported by athena)
 (defmethod sql.qp/->float :athena


### PR DESCRIPTION
Fixes #115 

This removes a timestamp cast from the `date_add` function. Neither the [official trino driver](https://github.com/starburstdata/metabase-driver/blob/b29d693a20affa5188ed3d10b4179a42787a498f/drivers/starburst/src/metabase/driver/implementation/query_processor.clj#L43) or the [presto driver](https://github.com/metabase/metabase/blob/23724872579c455048d6a782607adb358ceb64f5/modules/drivers/presto-common/src/metabase/driver/presto_common.clj#L53) do this, so not entirely sure why I did. 😁 